### PR TITLE
Ticket #126128 - Permettre l'ajout de pièces jointes par Drag&Drop sur les commentaires

### DIFF
--- a/app/overrides/issues/show.rb
+++ b/app/overrides/issues/show.rb
@@ -7,3 +7,12 @@ Deface::Override.new :virtual_path  => 'issues/show',
   @journals.reverse! if User.current.wants_comments_in_reverse_order?
 %>
 EOS
+Deface::Override.new :virtual_path  => 'issues/show',
+                     :name          => 'reorder-journals-in-show-issue_comments_new_form',
+                     :insert_after => 'div#history',
+                     :text          => <<EOS
+<% if @issue.editable? && User.current.allowed_to?(:set_notes_private, @project) %>
+  <%=  render "issue_comments/new_form" %>
+<% end %>
+EOS
+

--- a/app/views/issue_comments/_new_form.html.erb
+++ b/app/views/issue_comments/_new_form.html.erb
@@ -1,27 +1,30 @@
-<h3><%= l(:label_comment) %></h3>
+<div id="issue_comments_form" style="width: 100%;display:none">
+  <h3><%= l(:label_comment) %></h3>
 
-<%= labelled_form_for :journal, @issue.journals.build, url: issue_comments_path(issue_id: @issue.id), :html => { :id => "add_comment_form" } do |f| %>
+  <%= labelled_form_for :journal, @issue.journals.build, url: issue_comments_path(issue_id: @issue.id), :html => { :id => "add_comment_form" } do |f| %>
 
-  <%= error_messages_for 'issue' %>
-  <div class="box">
+    <%= error_messages_for 'issue' %>
+    <div class="box">
 
-    <%= render "issue_comments/visibility_form_fields" %>
 
-    <%= f.text_area :notes, :cols => 60, :rows => 10, :class => 'wiki-edit', :no_label => true, :id => 'issue_comment' %>
-    <%= wikitoolbar_for 'issue_comment' %>
+      <%= render "issue_comments/visibility_form_fields" %>
 
-    <%= f.hidden_field :private_notes, :value => true %>
+      <%= f.text_area :notes, :cols => 60, :rows => 10, :class => 'wiki-edit', :no_label => true, :id => 'issue_comment' %>
+      <%= wikitoolbar_for 'issue_comment' %>
 
-    <fieldset>
-      <legend><%= l(:label_attachment_plural) %></legend>
-      <div id="new-attachments" style="display:inline-block;">
-        <%= render :partial => 'attachments/form', :locals => { :container => Journal.new } %>
-      </div>
-    </fieldset>
-  </div>
+      <%= f.hidden_field :private_notes, :value => true %>
 
-  <%= submit_tag l(:button_add) %>
+      <fieldset>
+        <legend><%= l(:label_attachment_plural) %></legend>
+        <div id="new-attachments" style="display:inline-block;">
+          <%= render :partial => 'attachments/form', :locals => { :container => Journal.new } %>
+        </div>
+      </fieldset>
+    </div>
 
-<% end %>
+    <%= submit_tag l(:button_add) %>
 
-<div id="new_comment_preview" class="wiki"></div>
+  <% end %>
+
+  <div id="new_comment_preview" class="wiki"></div>
+</div>

--- a/app/views/issue_comments/_visibility_form_fields.html.erb
+++ b/app/views/issue_comments/_visibility_form_fields.html.erb
@@ -1,29 +1,11 @@
-<%
-  authorized_roles = roles_allowed_to_view_private_notes_from_role_or_function(@project)
-
-  if Redmine::Plugin.installed?(:redmine_limited_visibility)
-    user_roles = user_functions(@project, authorized_roles, User.current)
-    checked_roles = @journal.present? ? @journal.functions : default_checked_functions(@project, authorized_roles, User.current, @issue)
-    selectable_roles = selectable_functions(@project, authorized_roles)
-    functions_allowed_by_private_notes_groups = PrivateNotesGroup.where(group_id: user_roles.map(&:id)).map(&:function)
-    selectable_roles = selectable_roles & (functions_allowed_by_private_notes_groups | checked_roles) if functions_allowed_by_private_notes_groups.present?
-  else
-    user_roles = user_roles(@project, authorized_roles, User.current)
-    checked_roles = @journal.present? ? @journal.roles : default_checked_roles(@project, authorized_roles, User.current, @issue)
-    selectable_roles = selectable_roles(@project, authorized_roles)
-  end
-
-  selectable_roles = selectable_roles | checked_roles | user_roles
-%>
-
 <div class="visibility" style="margin-bottom: 0.2em;">
   <em class="info"><%= l(:text_info_comment_visibility) %></em>
 
-  <% selectable_roles.each do |role| %>
-    <% involved = "involved" if checked_roles.include?(role) %>
-    <% disabled = "disabled" if involved.present? && checked_roles.size == 1 %>
+  <% @selectable_roles.each do |role| %>
+    <% involved = "involved" if @checked_roles.include?(role) %>
+    <% disabled = "disabled" if involved.present? && @checked_roles.size == 1 %>
     <% css_classes = "#{involved} #{disabled} " %>
     <%= render "issue_comments/visibility_role", :function => role, styles: css_classes %>
   <% end %>
 </div>
-<%= hidden_field_tag "journal[visibility]", checked_roles.map(&:id).join('|'), id: "journal_visibility" %>
+<%= hidden_field_tag "journal[visibility]", @checked_roles.map(&:id).join('|'), id: "journal_visibility" %>

--- a/app/views/issue_comments/_visibility_form_fields.html.erb
+++ b/app/views/issue_comments/_visibility_form_fields.html.erb
@@ -5,7 +5,9 @@
     <% involved = "involved" if @checked_roles.include?(role) %>
     <% disabled = "disabled" if involved.present? && @checked_roles.size == 1 %>
     <% css_classes = "#{involved} #{disabled} " %>
-    <%= render "issue_comments/visibility_role", :function => role, styles: css_classes %>
+    <% if Redmine::Plugin.installed?(:redmine_limited_visibility) %>
+      <%= render "issue_comments/visibility_role", :function => role, styles: css_classes %>
+    <% end %>
   <% end %>
 </div>
 <%= hidden_field_tag "journal[visibility]", @checked_roles.map(&:id).join('|'), id: "journal_visibility" %>

--- a/app/views/issue_comments/new.html.erb
+++ b/app/views/issue_comments/new.html.erb
@@ -1,1 +1,0 @@
-<%= render "new_form" %>

--- a/app/views/issue_comments/new.js.erb
+++ b/app/views/issue_comments/new.js.erb
@@ -1,4 +1,2 @@
-if ($("#add_comment_form").length == 0) {
-  $("#update").after("<%= j render "new_form" %>")
-}
+$("#issue_comments_form").css('display','inline-block');
 showAndScrollTo("add_comment_form", "issue_comment")

--- a/init.rb
+++ b/init.rb
@@ -8,6 +8,7 @@ ActiveSupport::Reloader.to_prepare do
   require_dependency 'redmine_comments/attachment_patch'
   require_dependency 'redmine_comments/application_helper_patch'
   require_dependency 'redmine_comments/journals_helper_patch'
+  require_dependency 'redmine_comments/issues_controller_patch'
 end
 
 Redmine::Plugin.register :redmine_comments do

--- a/lib/redmine_comments/issues_controller_patch.rb
+++ b/lib/redmine_comments/issues_controller_patch.rb
@@ -1,0 +1,16 @@
+require_dependency 'issues_controller'
+
+class IssuesController < ApplicationController
+
+  before_action :get_roles_allowed_to_view, :only => [:show]
+
+  helper :issue_comments
+  include IssueCommentsHelper
+
+  private
+
+  def get_roles_allowed_to_view
+    @selectable_roles, @checked_roles = get_selectable_checked_roles(@project, @journal, @issue)
+  end
+
+end

--- a/lib/redmine_comments/journals_controller_patch.rb
+++ b/lib/redmine_comments/journals_controller_patch.rb
@@ -3,6 +3,7 @@ require_dependency 'journals_controller'
 class JournalsController
 
   append_before_action :update_visibility, :only => [:update]
+  before_action :get_roles_allowed_to_view, :only => [:edit]
 
   helper :attachments
   include AttachmentsHelper
@@ -11,6 +12,10 @@ class JournalsController
   include IssueCommentsHelper
 
   private
+
+  def get_roles_allowed_to_view
+   @selectable_roles, @checked_roles = get_selectable_checked_roles(@project, @journal, @issue)
+  end
 
   def update_visibility
     visibility_params = params[:journal][:visibility]

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -59,7 +59,7 @@ describe "creating new comments", type: :system do
     journal = issue.journals.last
     expect(journal.private_notes).to be_truthy
     expect(journal.notes).to eq 'Here is a quick note'
-    expect(journal.roles).to be_empty
+    expect(journal.roles).to be_empty if Redmine::Plugin.installed?(:redmine_limited_visibility)
 
     issue.reload
     expect(issue.updated_on).to be > journal.created_on


### PR DESCRIPTION
Implémentation de la correction :
  - Ajout de pièces jointe par drag&drop : OK
  - Vérification du copier/coller de l'image : OK
  - Ajout de la dépendance manquante : redmine_limited_visibility